### PR TITLE
Downgrade app to run on tWAS 8.5.5

### DIFF
--- a/websphere-cafe-web/src/main/resources/META-INF/persistence.xml
+++ b/websphere-cafe-web/src/main/resources/META-INF/persistence.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.1"
-	xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+<persistence version="2.0"
+	xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd">
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
 	<persistence-unit name="coffees">
 		<jta-data-source>jdbc/WebSphereCafeDB</jta-data-source>
 		<properties>
@@ -11,9 +11,8 @@
 				value="create" />
 			<property name="openjpa.jdbc.SynchronizeMappings"
 				value="buildSchema" />
-			<property name="eclipselink.logging.level.sql" value="FINE" />
-			<property name="eclipselink.logging.parameters" value="true" />
-			<property name="hibernate.show_sql" value="true" />
+			<property name="openjpa.Log"
+				value="SQL=TRACE" />
 		</properties>
 	</persistence-unit>
 </persistence>


### PR DESCRIPTION
Fixes #1.

persistence.xml was using JPA 2.1. tWAS 8.5.5 uses JPA 2.0. I asked the AI to rewrite it to use JPA 2.0. Now it deploys.

modified:   websphere-cafe-web/src/main/resources/META-INF/persistence.xml
